### PR TITLE
makefile.unix creates obj directory and depends on and builds cryptopp

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -17,7 +17,7 @@ DEFS=-DBOOST_SPIRIT_THREADSAFE -D_FILE_OFFSET_BITS=64
 
 DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/obj $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH) $(OPENSSL_INCLUDE_PATH))
 DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/obj $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH) $(OPENSSL_INCLUDE_PATH))
-LIBS = $(addprefix -L,$(BOOST_LIB_PATH) $(BDB_LIB_PATH) $(OPENSSL_LIB_PATH)) -l pthread cryptopp/libcryptopp.a -l boost_system -l boost_program_options -l boost_thread -l boost_filesystem
+LIBS = $(addprefix -L,$(BOOST_LIB_PATH) $(BDB_LIB_PATH) $(OPENSSL_LIB_PATH)) -l pthread -l boost_system -l boost_program_options -l boost_thread -l boost_filesystem
 
 TESTDEFS = -DTEST_DATA_DIR=$(abspath test/data)
 
@@ -112,6 +112,7 @@ xCXXFLAGS=-O2 -pthread -Wall -Wextra -Wformat -Wformat-security -Wno-unused-para
 xLDFLAGS=$(LDHARDENING) $(LDFLAGS)
 
 OBJS= \
+		cryptopp/libcryptopp.a \
     leveldb/libleveldb.a \
     obj/alert.o \
     obj/version.o \
@@ -149,7 +150,7 @@ OBJS= \
 	
 
 
-all: maxcoind
+all: obj maxcoind
 
 test check: test_maxcoin FORCE
 	./test_maxcoin
@@ -158,7 +159,8 @@ test check: test_maxcoin FORCE
 # LevelDB support
 #
 MAKEOVERRIDES =
-LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a
+LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a $(CURDIR)/cryptopp/libcryptopp.a
+
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/helpers)
 leveldb/libleveldb.a:
@@ -187,6 +189,12 @@ obj/%.o: %.c
 	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
 	  rm -f $(@:%.o=%.d)
 
+obj:
+	-mkdir -p obj
+
+cryptopp/libcryptopp.a:
+	@$(MAKE) -C cryptopp
+
 maxcoind: $(OBJS:obj/%=obj/%)
 	$(LINK) $(xCXXFLAGS) -o $@ $^ $(xLDFLAGS) $(LIBS)
 
@@ -210,5 +218,6 @@ clean:
 	-rm -f obj-test/*.P
 	-rm -f obj/build.h
 	-cd leveldb && $(MAKE) clean || true
+	-cd cryptopp && $(MAKE) clean || true
 
 FORCE:


### PR DESCRIPTION
This fixes two issues with building the maxcoind on linux.
1. Creates the src/obj directory, needed to compile the source.
2. Actually builds libcryptopp and links with it, instead of just trying to link with cryptopp/libcryptopp.a (that doesn't magically exist before it's built).

compile as per the instructions:
cd src && make -f makefile.unix
